### PR TITLE
[Follow/DM] TODO 변경 예정사항 수정

### DIFF
--- a/src/main/java/com/samsamotot/otboo/directmessage/controller/DirectMessageController.java
+++ b/src/main/java/com/samsamotot/otboo/directmessage/controller/DirectMessageController.java
@@ -1,6 +1,7 @@
 package com.samsamotot.otboo.directmessage.controller;
 
 import com.samsamotot.otboo.common.dto.CursorResponse;
+import com.samsamotot.otboo.directmessage.controller.api.DirectMessageApi;
 import com.samsamotot.otboo.directmessage.dto.DirectMessageListResponse;
 import com.samsamotot.otboo.directmessage.dto.MessageRequest;
 import com.samsamotot.otboo.directmessage.entity.DirectMessage;
@@ -26,7 +27,7 @@ import java.util.UUID;
 @RestController
 @Validated
 @RequestMapping("api/direct-messages")
-public class DirectMessageController {
+public class DirectMessageController implements DirectMessageApi {
 
     private final DirectMessageService directMessageService;
 

--- a/src/main/java/com/samsamotot/otboo/directmessage/controller/api/DirectMessageApi.java
+++ b/src/main/java/com/samsamotot/otboo/directmessage/controller/api/DirectMessageApi.java
@@ -1,0 +1,56 @@
+package com.samsamotot.otboo.directmessage.controller.api;
+
+import com.samsamotot.otboo.directmessage.dto.DirectMessageListResponse;
+import com.samsamotot.otboo.directmessage.dto.MessageRequest;
+import com.samsamotot.otboo.directmessage.service.DirectMessageService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Min;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.ErrorResponse;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.Locale;
+import java.util.UUID;
+
+/**
+ * PackageName  : com.samsamotot.otboo.directmessage.controller.api
+ * FileName     : DirectMessageApi
+ * Author       : dounguk
+ * Date         : 2025. 9. 25.
+ */
+@Tag(name = "DM 목록 조회",description = "DM 목록 조회 API" )
+public interface DirectMessageApi {
+
+    @Operation(summary = "DM 목록 조회")
+    @ApiResponses(value = {
+        @ApiResponse(
+            responseCode = "200",
+            description = "DM 목록 조회 성공",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = DirectMessageListResponse.class))
+        ),
+        @ApiResponse(
+            responseCode = "400",
+            description = "DM 목록 조회 실패",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = ErrorResponse.class))
+        )
+    }
+    )
+    @GetMapping
+    ResponseEntity<DirectMessageListResponse> directMessages(
+        @RequestParam UUID userId,
+        @RequestParam(required = false) String cursor,
+        @RequestParam(required = false) UUID idAfter,
+        @RequestParam Integer limit
+    );
+}

--- a/src/main/java/com/samsamotot/otboo/directmessage/service/DirectMessageServiceImpl.java
+++ b/src/main/java/com/samsamotot/otboo/directmessage/service/DirectMessageServiceImpl.java
@@ -114,13 +114,17 @@ public class DirectMessageServiceImpl implements DirectMessageService {
     private UUID currentUserId() {
         var auth = SecurityContextHolder.getContext().getAuthentication();
         if (auth == null || !auth.isAuthenticated() || auth.getPrincipal() == null) {
-            // 인증 실패 로그
+            log.warn(DM_SERVICE + "인증 실패: Authentication 비어있음/미인증 (auth={}, principal={})", auth, (auth != null ? auth.getPrincipal() : null));
             throw new OtbooException(ErrorCode.UNAUTHORIZED);
         }
 
         String email = auth.getName();
         return userRepository.findByEmail(email)
             .map(User::getId)
-            .orElseThrow(() -> new OtbooException(ErrorCode.UNAUTHORIZED));
+            .orElseThrow(() -> {
+                log.warn(DM_SERVICE + "인증 사용자 조회 실패: email={} (DB에 없음)", email);
+                return new OtbooException(ErrorCode.UNAUTHORIZED);
+            });
     }
+
 }

--- a/src/main/java/com/samsamotot/otboo/directmessage/service/DirectMessageServiceImpl.java
+++ b/src/main/java/com/samsamotot/otboo/directmessage/service/DirectMessageServiceImpl.java
@@ -39,12 +39,10 @@ public class DirectMessageServiceImpl implements DirectMessageService {
 
     private final DirectMessageMapper directMessageMapper;
 
-    // TODO DM 목록 조회 : me 정보 가져오는 로직 수정 필요
     @Override
     public DirectMessageListResponse getMessages(MessageRequest request) {
         log.info(DM_SERVICE + "DM 목록 조회 시작 - request: {}", request);
-//        UUID myId = UUID.fromString("a0000000-0000-0000-0000-000000000001"); // TODO 추후 currentUserId() 로 수정
-        UUID myId = currentUserId(); // 추가됨 9/25
+        UUID myId = currentUserId();
         UUID otherId = request.userId();
 
         User me = userRepository.findById(myId)
@@ -113,7 +111,6 @@ public class DirectMessageServiceImpl implements DirectMessageService {
         }
     }
 
-    // TODO 로그인 로직 추가되면 사용 예정
     private UUID currentUserId() {
         var auth = SecurityContextHolder.getContext().getAuthentication();
         if (auth == null || !auth.isAuthenticated() || auth.getPrincipal() == null) {

--- a/src/main/java/com/samsamotot/otboo/directmessage/service/DirectMessageServiceImpl.java
+++ b/src/main/java/com/samsamotot/otboo/directmessage/service/DirectMessageServiceImpl.java
@@ -43,7 +43,8 @@ public class DirectMessageServiceImpl implements DirectMessageService {
     @Override
     public DirectMessageListResponse getMessages(MessageRequest request) {
         log.info(DM_SERVICE + "DM 목록 조회 시작 - request: {}", request);
-        UUID myId = UUID.fromString("a0000000-0000-0000-0000-000000000001"); // TODO 추후 currentUserId() 로 수정
+//        UUID myId = UUID.fromString("a0000000-0000-0000-0000-000000000001"); // TODO 추후 currentUserId() 로 수정
+        UUID myId = currentUserId(); // 추가됨 9/25
         UUID otherId = request.userId();
 
         User me = userRepository.findById(myId)
@@ -112,10 +113,17 @@ public class DirectMessageServiceImpl implements DirectMessageService {
         }
     }
 
-    // TODO 로그인 로직 추가되면 사용 예정 - 커버리지 문제로 제거 상태
-//    private static UUID currentUserId() {
-//        var auth = SecurityContextHolder.getContext().getAuthentication();
-//        if (auth == null || auth.getName() == null) throw new OtbooException(ErrorCode.UNAUTHORIZED);
-//        return UUID.fromString(auth.getName());
-//    }
+    // TODO 로그인 로직 추가되면 사용 예정
+    private UUID currentUserId() {
+        var auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth == null || !auth.isAuthenticated() || auth.getPrincipal() == null) {
+            // 인증 실패 로그
+            throw new OtbooException(ErrorCode.UNAUTHORIZED);
+        }
+
+        String email = auth.getName();
+        return userRepository.findByEmail(email)
+            .map(User::getId)
+            .orElseThrow(() -> new OtbooException(ErrorCode.UNAUTHORIZED));
+    }
 }

--- a/src/main/java/com/samsamotot/otboo/follow/controller/FollowController.java
+++ b/src/main/java/com/samsamotot/otboo/follow/controller/FollowController.java
@@ -47,7 +47,6 @@ public class FollowController implements FollowApi {
     }
 
 
-    // TODO 팔로우 요약 정보 조회 - 주석 추가
     @GetMapping("/summary")
     public ResponseEntity<FollowSummaryDto> followSummary(@RequestParam UUID userId) {
         return ResponseEntity.ok().body(followService.findFollowSummaries(userId));
@@ -79,7 +78,7 @@ public class FollowController implements FollowApi {
     public ResponseEntity<FollowListResponse> getFollowings(
         @RequestParam UUID followerId,
         @RequestParam(required = false) String cursor,
-        @RequestParam(required = false) UUID idAfter, //
+        @RequestParam(required = false) UUID idAfter,
         @RequestParam Integer limit,
         @RequestParam(required = false) String nameLike
     ) {

--- a/src/main/java/com/samsamotot/otboo/follow/service/FollowServiceImpl.java
+++ b/src/main/java/com/samsamotot/otboo/follow/service/FollowServiceImpl.java
@@ -110,13 +110,9 @@ public class FollowServiceImpl implements FollowService {
     }
 
 
-    // TODO 팔로우 요약 정보 조회 - 주석 추가
     @Override
     public FollowSummaryDto findFollowSummaries(UUID userId) {
-        // TODO: 임시 구현 - Authentication/Security 적용 후 실제 로그인 사용자 ID로 교체 필요
-//        UUID loggedInUserId = UUID.randomUUID(); // 임시값: 항상 USER_NOT_FOUND 발생
         log.info(FOLLOW_SERVICE + "팔로우 요약 조회 시작: targetUserId={}", userId);
-//        log.warn(FOLLOW_SERVICE + "임시 UUID 사용 중. Security 적용 후 Authentication 기반으로 교체 필요: tempLoggedInUserId={}", loggedInUserId);
         UUID loggedInUserId = currentUserId();
 
 

--- a/src/main/java/com/samsamotot/otboo/follow/service/FollowServiceImpl.java
+++ b/src/main/java/com/samsamotot/otboo/follow/service/FollowServiceImpl.java
@@ -11,6 +11,7 @@ import com.samsamotot.otboo.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -108,13 +109,15 @@ public class FollowServiceImpl implements FollowService {
         }
     }
 
+
     // TODO 팔로우 요약 정보 조회 - 주석 추가
     @Override
     public FollowSummaryDto findFollowSummaries(UUID userId) {
         // TODO: 임시 구현 - Authentication/Security 적용 후 실제 로그인 사용자 ID로 교체 필요
-        UUID loggedInUserId = UUID.randomUUID(); // 임시값: 항상 USER_NOT_FOUND 발생
+//        UUID loggedInUserId = UUID.randomUUID(); // 임시값: 항상 USER_NOT_FOUND 발생
         log.info(FOLLOW_SERVICE + "팔로우 요약 조회 시작: targetUserId={}", userId);
-        log.warn(FOLLOW_SERVICE + "임시 UUID 사용 중. Security 적용 후 Authentication 기반으로 교체 필요: tempLoggedInUserId={}", loggedInUserId);
+//        log.warn(FOLLOW_SERVICE + "임시 UUID 사용 중. Security 적용 후 Authentication 기반으로 교체 필요: tempLoggedInUserId={}", loggedInUserId);
+        UUID loggedInUserId = currentUserId();
 
 
         User loggedInUser = userRepository.findById(loggedInUserId).orElseThrow(() -> new OtbooException(ErrorCode.USER_NOT_FOUND));
@@ -339,5 +342,18 @@ public class FollowServiceImpl implements FollowService {
         } catch (Exception ignore) {
         }
         return null;
+    }
+
+    private UUID currentUserId() {
+        var auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth == null || !auth.isAuthenticated() || auth.getPrincipal() == null) {
+            // 인증 실패 로그
+            throw new OtbooException(ErrorCode.UNAUTHORIZED);
+        }
+
+        String email = auth.getName();
+        return userRepository.findByEmail(email)
+            .map(User::getId)
+            .orElseThrow(() -> new OtbooException(ErrorCode.UNAUTHORIZED));
     }
 }

--- a/src/main/java/com/samsamotot/otboo/follow/service/FollowServiceImpl.java
+++ b/src/main/java/com/samsamotot/otboo/follow/service/FollowServiceImpl.java
@@ -343,13 +343,16 @@ public class FollowServiceImpl implements FollowService {
     private UUID currentUserId() {
         var auth = SecurityContextHolder.getContext().getAuthentication();
         if (auth == null || !auth.isAuthenticated() || auth.getPrincipal() == null) {
-            // 인증 실패 로그
+            log.warn(FOLLOW_SERVICE + "인증 실패: Authentication 비어있음/미인증 (auth={}, principal={})", auth, (auth != null ? auth.getPrincipal() : null));
             throw new OtbooException(ErrorCode.UNAUTHORIZED);
         }
 
         String email = auth.getName();
         return userRepository.findByEmail(email)
             .map(User::getId)
-            .orElseThrow(() -> new OtbooException(ErrorCode.UNAUTHORIZED));
+            .orElseThrow(() -> {
+                log.warn(FOLLOW_SERVICE + "인증 사용자 조회 실패: email={} (DB에 없음)", email);
+                return new OtbooException(ErrorCode.UNAUTHORIZED);
+            });
     }
 }

--- a/src/test/java/com/samsamotot/otboo/directmessage/service/DirectMessageServiceImplTest.java
+++ b/src/test/java/com/samsamotot/otboo/directmessage/service/DirectMessageServiceImplTest.java
@@ -69,7 +69,7 @@ class DirectMessageServiceImplTest {
     }
 
     private static void loginAsEmail(String email) {
-        var auth = new UsernamePasswordAuthenticationToken(email, null, null);
+        var auth = new UsernamePasswordAuthenticationToken(email, "N/A", java.util.List.of());
         SecurityContextHolder.getContext().setAuthentication(auth);
     }
 


### PR DESCRIPTION
## #️⃣ Issue Number

Closes #94 

## 📝 요약(Summary)
팔로 요약정보 조회, dm 메세지 목록 조회 로그인 유저 기반으로 조회 할 수 있게 수정
DM 목록조회 swagger 문서 추가

## 🛠️ PR 변경 사항


- [x] 기능 추가 (Feature)
- [ ] 버그 수정 (Fix)
- [x] 코드 리팩토링 (Refactor)
- [x] 테스트 코드 추가/수정 (Test)
- [x] 문서 수정 (Docs)
- [ ] 스타일/UI 수정 (Style/UI)
- [ ] 빌드/설정 변경 (Build/Config)

## 📸스크린샷 (선택)
<!-- UI 변경이 있다면 Before / After 스크린샷을 첨부해주세요 -->

## 💬 리뷰 포인트 / 논의사항
<!-- 리뷰어가 집중해서 봐야 하는 부분이나 논의가 필요한 내용을 적어주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist
<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] 커밋 메시지를 컨벤션에 맞게 작성했습니다.
- [ ] 코드 스타일/린트 검사를 통과했습니다.
- [x] 변경 사항에 대한 테스트를 수행했습니다.
- [x] 문서(README 등)를 최신 상태로 업데이트했습니다. (해당 시)
- [ ] 리뷰어 피드백을 반영했습니다. (PR 업데이트 시)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - Direct Messages 목록 조회 API 추가: 사용자 ID, 커서, idAfter, limit 파라미터 지원 및 스웨거 메타데이터 제공.
- 버그 수정
  - Direct Messages와 팔로우 요약이 더 이상 임시 사용자 식별자를 사용하지 않고, 로그인한 사용자 정보를 기반으로 동작.
  - 인증 누락/미인증 및 사용자 미존재 시 적절한 오류 응답 반환.
  - 잘못된 커서 형식에 대한 유효성 검증 강화로 일관된 오류 처리.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->