### PR TITLE
[Feed] 피드 좋아요수, 댓글수 카운트 업데이트 시 updatedAt 필드 갱신되도록 수정

### DIFF
--- a/src/main/java/com/samsamotot/otboo/feed/repository/FeedRepository.java
+++ b/src/main/java/com/samsamotot/otboo/feed/repository/FeedRepository.java
@@ -3,6 +3,7 @@ package com.samsamotot.otboo.feed.repository;
 import com.samsamotot.otboo.feed.entity.Feed;
 import java.util.Optional;
 import java.util.UUID;
+import java.time.Instant;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -17,21 +18,41 @@ public interface FeedRepository extends JpaRepository<Feed, UUID>, FeedRepositor
 
     // 특정 피드의 좋아요 수를 1 증가시킵니다.
     @Modifying(flushAutomatically = true, clearAutomatically = true)
-    @Query("update Feed f set f.likeCount = f.likeCount + 1 where f.id = :feedId")
+    @Query(value = """
+        update feeds
+           set like_count = like_count + 1,
+               updated_at = CURRENT_TIMESTAMP
+         where id = :feedId
+        """, nativeQuery = true)
     int incrementLikeCount(@Param("feedId") UUID feedId);
 
     // 특정 피드의 좋아요 수를 1 감소시킵니다. (0 이하로 내려가지 않음)
     @Modifying(flushAutomatically = true, clearAutomatically = true)
-    @Query("update Feed f set f.likeCount = case when f.likeCount > 0 then f.likeCount - 1 else 0 end where f.id = :feedId")
+    @Query(value = """
+        update feeds
+           set like_count = case when like_count > 0 then like_count - 1 else 0 end,
+               updated_at = CURRENT_TIMESTAMP
+         where id = :feedId
+        """, nativeQuery = true)
     int decrementLikeCount(@Param("feedId") UUID feedId);
 
     // 특정 피드의 댓글 수를 1 증가시킵니다.
     @Modifying(flushAutomatically = true, clearAutomatically = true)
-    @Query("update Feed f set f.commentCount = f.commentCount + 1 where f.id = :feedId")
+    @Query(value = """
+        update feeds
+           set comment_count = comment_count + 1,
+               updated_at = CURRENT_TIMESTAMP
+         where id = :feedId
+        """, nativeQuery = true)
     int incrementCommentCount(@Param("feedId") UUID feedId);
 
     // 특정 피드의 댓글 수를 1 감소시킵니다. (0 이하로 내려가지 않음)
     @Modifying(flushAutomatically = true, clearAutomatically = true)
-    @Query("update Feed f set f.commentCount = case when f.commentCount > 0 then f.commentCount - 1 else 0 end where f.id = :feedId")
+    @Query(value = """
+        update feeds
+           set comment_count = case when comment_count > 0 then comment_count - 1 else 0 end,
+               updated_at = CURRENT_TIMESTAMP
+         where id = :feedId
+        """, nativeQuery = true)
     int decrementCommentCount(@Param("feedId") UUID feedId);
 }

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -180,3 +180,30 @@ INSERT INTO recommendation_clothes (id, recommendation_id, clothes_id, created_a
 (gen_random_uuid(), '80000000-0000-0000-0000-000000000003', 'e0000000-0000-0000-0000-000000000003', NOW()),
 (gen_random_uuid(), '80000000-0000-0000-0000-000000000004', 'e0000000-0000-0000-0000-000000000004', NOW()),
 (gen_random_uuid(), '80000000-0000-0000-0000-000000000005', 'e0000000-0000-0000-0000-000000000005', NOW());
+
+
+-- 좋아요 카운트 백필
+UPDATE feeds f
+SET like_count = COALESCE(sub.cnt, 0),
+    updated_at = NOW()
+FROM (
+         SELECT feed_id, COUNT(*) AS cnt
+         FROM feed_likes
+         GROUP BY feed_id
+     ) sub
+WHERE f.id = sub.feed_id;
+
+-- 댓글 카운트 백필
+UPDATE feeds f
+SET comment_count = COALESCE(sub.cnt, 0),
+    updated_at = NOW()
+FROM (
+         SELECT feed_id, COUNT(*) AS cnt
+         FROM comments
+         GROUP BY feed_id
+     ) sub
+WHERE f.id = sub.feed_id;
+
+-- 혹시 남아있을 NULL 정리
+UPDATE feeds SET like_count = COALESCE(like_count, 0);
+UPDATE feeds SET comment_count = COALESCE(comment_count, 0);


### PR DESCRIPTION
## #️⃣ Issue Number
<!-- 관련된 이슈 번호를 적어주세요. 예시:Closes #21 -->
Closes #92 

## 📝 요약(Summary)
<!-- 무엇을, 왜 변경했는지 간단히 설명해주세요 -->
- AS-IS: 피드 좋아요/댓글 카운트 업데이트 시 updatedAt 미갱신
  - 원인: JPQL 기반 벌크 UPDATE로 전환하면서 Auditing(@LastModifiedDate) 비적용 → updatedAt 자동 갱신 누락
  - 조치: 네이티브 UPDATE로 전환하여 updated_at = CURRENT_TIMESTAMP 명시 (JPQL Timestamp ↔ Instant 타입 불일치 이슈 회피)
- TO-BE: 카운트 업데이트시 updatedAt 필드 갱신됨

## 🛠️ PR 변경 사항
<-- 어떤 변경 사항이 있나요? -->

- [ ] 기능 추가 (Feature)
- [x] 버그 수정 (Fix)
- [ ] 코드 리팩토링 (Refactor)
- [ ] 테스트 코드 추가/수정 (Test)
- [ ] 문서 수정 (Docs)
- [ ] 스타일/UI 수정 (Style/UI)
- [ ] 빌드/설정 변경 (Build/Config)

## 📸스크린샷 (선택)
<!-- UI 변경이 있다면 Before / After 스크린샷을 첨부해주세요 -->
- 좋아요 클릭
<img width="287" height="330" alt="스크린샷 2025-09-26 오전 11 39 49" src="https://github.com/user-attachments/assets/07b05064-f43e-4f64-aa4d-1d60289a3240" />

- before
<img width="1205" height="212" alt="스크린샷 2025-09-26 오전 11 38 39" src="https://github.com/user-attachments/assets/6694ecf1-410b-4e13-b9e2-a3afdd11bb08" />

-after
<img width="1236" height="200" alt="스크린샷 2025-09-26 오전 11 40 04" src="https://github.com/user-attachments/assets/0c10c43d-8cf4-4b4d-8049-13fc2919cff8" />


## 💬 리뷰 포인트 / 논의사항
<!-- 리뷰어가 집중해서 봐야 하는 부분이나 논의가 필요한 내용을 적어주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
- data.sql문에 더미 데이터의 좋아요수,댓글수 업데이트 하는 로직 추가하였습니다.

## ✅ PR Checklist
<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] 커밋 메시지를 컨벤션에 맞게 작성했습니다.
- [ ] 코드 스타일/린트 검사를 통과했습니다.
- [ ] 변경 사항에 대한 테스트를 수행했습니다.
- [ ] 문서(README 등)를 최신 상태로 업데이트했습니다. (해당 시)
- [ ] 리뷰어 피드백을 반영했습니다. (PR 업데이트 시)
