### PR TITLE
[USER] JWT 토큰 블랙리스트 

### DIFF
--- a/src/main/java/com/samsamotot/otboo/common/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/samsamotot/otboo/common/security/jwt/JwtTokenProvider.java
@@ -1,5 +1,12 @@
 package com.samsamotot.otboo.common.security.jwt;
 
+import java.time.Instant;
+import java.util.Date;
+import java.util.UUID;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.JWSHeader;
@@ -11,13 +18,8 @@ import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
 import com.samsamotot.otboo.common.exception.ErrorCode;
 import com.samsamotot.otboo.common.exception.OtbooException;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Component;
 
-import java.time.Instant;
-import java.util.Date;
-import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * JWT(JSON Web Token) 토큰 생성 및 검증을 담당하는 핵심 클래스
@@ -214,6 +216,34 @@ public class JwtTokenProvider {
             return claims.getExpirationTime().getTime() / 1000;
         } catch (Exception e) {
             log.error("토큰 만료 시간 조회 실패 - 토큰: {}", token, e);
+            return null;
+        }
+    }
+
+    /**
+     * 토큰 발급 시간(iat)을 epoch seconds로 반환합니다.
+     */
+    public Long getIssuedAtEpochSeconds(String token) {
+        try {
+            SignedJWT signedJWT = SignedJWT.parse(token);
+            JWTClaimsSet claims = signedJWT.getJWTClaimsSet();
+            Date issuedAt = claims.getIssueTime();
+            return issuedAt != null ? issuedAt.getTime() / 1000 : null;
+        } catch (Exception e) {
+            log.error("토큰 발급 시간 조회 실패 - 토큰: {}", token, e);
+            return null;
+        }
+    }
+
+    /**
+     * 토큰 고유 ID(jti)를 반환합니다.
+     */
+    public String getJti(String token) {
+        try {
+            SignedJWT signedJWT = SignedJWT.parse(token);
+            return signedJWT.getJWTClaimsSet().getJWTID();
+        } catch (Exception e) {
+            log.error("토큰 JTI 조회 실패 - 토큰: {}", token, e);
             return null;
         }
     }

--- a/src/main/java/com/samsamotot/otboo/common/security/jwt/TokenInvalidationService.java
+++ b/src/main/java/com/samsamotot/otboo/common/security/jwt/TokenInvalidationService.java
@@ -1,0 +1,95 @@
+package com.samsamotot.otboo.common.security.jwt;
+
+import java.time.Instant;
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * JWT 무효화(블랙리스트 및 사용자 단위 컷오프) 관리를 위한 서비스
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class TokenInvalidationService {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    private static final String BLACKLIST_PREFIX = "jwt:blacklist:"; // + {jti}
+    private static final String USER_INVALID_AFTER_PREFIX = "jwt:user:"; // + {userId}:invalidAfter
+
+    /**
+     * 주어진 jti(JWT ID)를 블랙리스트에 등록합니다.
+     * 
+     * @param jti        블랙리스트에 등록할 JWT ID
+     * @param ttlSeconds 블랙리스트 유지 시간(초)
+     */
+    public void blacklistJti(String jti, long ttlSeconds) {
+        if (jti == null || jti.isBlank()) return;
+        String key = BLACKLIST_PREFIX + jti;
+        redisTemplate.opsForValue().set(key, Boolean.TRUE, ttlSeconds, TimeUnit.SECONDS);
+        log.debug("블랙리스트 등록 - jti: {}, ttl: {}s", jti, ttlSeconds);
+    }
+
+    /**
+     * 주어진 jti(JWT ID)가 블랙리스트에 등록되어 있는지 확인합니다.
+     * 
+     * @param jti 확인할 JWT ID
+     * @return 블랙리스트에 있으면 true, 아니면 false
+     */
+    public boolean isBlacklisted(String jti) {
+        if (jti == null || jti.isBlank()) return false;
+        String key = BLACKLIST_PREFIX + jti;
+        Boolean exists = redisTemplate.hasKey(key);
+        return Boolean.TRUE.equals(exists);
+    }
+
+    /**
+     * 특정 사용자의 invalidAfter(컷오프) 시각을 설정합니다.
+     * 
+     * @param userId       컷오프를 설정할 사용자 ID
+     * @param invalidAfter 컷오프 시각(Instant)
+     */
+    public void setUserInvalidAfter(String userId, Instant invalidAfter) {
+        if (userId == null || userId.isBlank() || invalidAfter == null) return;
+        String key = buildInvalidAfterKey(userId);
+        // 값은 epoch millis로 저장
+        redisTemplate.opsForValue().set(key, invalidAfter.toEpochMilli());
+        log.info("사용자 컷오프 설정 - userId: {}, invalidAfter: {}", userId, invalidAfter);
+    }
+
+    /**
+     * 특정 사용자의 invalidAfter(컷오프) 시각을 epoch millis로 조회합니다.
+     * 
+     * @param userId 조회할 사용자 ID
+     * @return 컷오프 시각(epoch millis), 없으면 null
+     */
+    public Long getUserInvalidAfterMillis(String userId) {
+        if (userId == null || userId.isBlank()) return null;
+        Object value = redisTemplate.opsForValue().get(buildInvalidAfterKey(userId));
+        if (value instanceof Number number) {
+            return number.longValue();
+        }
+        try {
+            return value != null ? Long.parseLong(String.valueOf(value)) : null;
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    /**
+     * 사용자 ID로부터 컷오프 Redis 키를 생성합니다.
+     * 
+     * @param userId 사용자 ID
+     * @return 컷오프 Redis 키
+     */
+    private String buildInvalidAfterKey(String userId) {
+        return USER_INVALID_AFTER_PREFIX + userId + ":invalidAfter";
+    }
+}
+
+

--- a/src/main/java/com/samsamotot/otboo/common/security/jwt/TokenInvalidationService.java
+++ b/src/main/java/com/samsamotot/otboo/common/security/jwt/TokenInvalidationService.java
@@ -30,6 +30,10 @@ public class TokenInvalidationService {
      */
     public void blacklistJti(String jti, long ttlSeconds) {
         if (jti == null || jti.isBlank()) return;
+        if (ttlSeconds <= 0) {
+            // TTL이 0 이하이면 등록할 필요가 없으므로 조기 종료
+            return;
+        }
         String key = BLACKLIST_PREFIX + jti;
         redisTemplate.opsForValue().set(key, Boolean.TRUE, ttlSeconds, TimeUnit.SECONDS);
         log.debug("블랙리스트 등록 - jti: {}, ttl: {}s", jti, ttlSeconds);

--- a/src/test/java/com/samsamotot/otboo/common/security/jwt/JwtAuthenticationFilterTest.java
+++ b/src/test/java/com/samsamotot/otboo/common/security/jwt/JwtAuthenticationFilterTest.java
@@ -1,0 +1,114 @@
+package com.samsamotot.otboo.common.security.jwt;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import com.samsamotot.otboo.common.config.SecurityProperties;
+import com.samsamotot.otboo.user.service.UserService;
+
+public class JwtAuthenticationFilterTest {
+
+  private JwtTokenProvider jwtTokenProvider;
+  private TokenInvalidationService tokenInvalidationService;
+  private UserService userService;
+  private SecurityProperties securityProperties;
+  private JwtAuthenticationFilter filter;
+
+  @BeforeEach
+  void setUp() {
+    jwtTokenProvider = mock(JwtTokenProvider.class);
+    tokenInvalidationService = mock(TokenInvalidationService.class);
+    userService = mock(UserService.class);
+    securityProperties = new SecurityProperties();
+    SecurityProperties.Cookie cookie = new SecurityProperties.Cookie();
+    cookie.setSecure(false);
+    cookie.setSameSite("Lax");
+    securityProperties.setCookie(cookie);
+
+    filter = new JwtAuthenticationFilter(jwtTokenProvider, tokenInvalidationService, userService, securityProperties);
+  }
+
+  private MockHttpServletRequest authRequest(String token) {
+    MockHttpServletRequest req = new MockHttpServletRequest();
+    req.setRequestURI("/api/sse");
+    req.addHeader("Authorization", "Bearer " + token);
+    return req;
+  }
+
+  @Test
+  @DisplayName("블랙리스트 토큰이면 401과 X-Auth-Error, 삭제 쿠키를 반환한다")
+  void blacklist_returns401_and_clearsCookie() throws Exception {
+    String token = "t.jwt";
+    String jti = "jti-123";
+    UUID userId = UUID.randomUUID();
+
+    when(jwtTokenProvider.validateToken(token)).thenReturn(true);
+    doReturn(userId).when(jwtTokenProvider).getUserIdFromToken(token);
+    when(jwtTokenProvider.getJti(token)).thenReturn(jti);
+    when(tokenInvalidationService.isBlacklisted(jti)).thenReturn(true);
+
+    MockHttpServletResponse res = new MockHttpServletResponse();
+    filter.doFilterInternal(authRequest(token), res, new MockFilterChain());
+
+    assertThat(res.getStatus()).isEqualTo(401);
+    assertThat(res.getHeader("X-Auth-Error")).isEqualTo("TOKEN_BLACKLISTED");
+    String setCookie = res.getHeader("Set-Cookie");
+    assertThat(setCookie).contains("REFRESH_TOKEN=");
+    assertThat(setCookie).contains("Max-Age=0");
+  }
+
+  @Test
+  @DisplayName("컷오프 이전에 발급된 토큰이면 401과 X-Auth-Error, 삭제 쿠키를 반환한다")
+  void cutoff_returns401_and_clearsCookie() throws Exception {
+    String token = "t.jwt";
+    UUID userId = UUID.randomUUID();
+
+    when(jwtTokenProvider.validateToken(token)).thenReturn(true);
+    doReturn(userId).when(jwtTokenProvider).getUserIdFromToken(token);
+    when(jwtTokenProvider.getJti(token)).thenReturn("jti-x");
+    when(tokenInvalidationService.isBlacklisted("jti-x")).thenReturn(false);
+    // iat 100, invalidAfter 200 (millis)
+    when(jwtTokenProvider.getIssuedAtEpochSeconds(token)).thenReturn(100L);
+    when(tokenInvalidationService.getUserInvalidAfterMillis(userId.toString())).thenReturn(200_000L);
+
+    MockHttpServletResponse res = new MockHttpServletResponse();
+    filter.doFilterInternal(authRequest(token), res, new MockFilterChain());
+
+    assertThat(res.getStatus()).isEqualTo(401);
+    assertThat(res.getHeader("X-Auth-Error")).isEqualTo("TOKEN_CUTOFF");
+    String setCookie = res.getHeader("Set-Cookie");
+    assertThat(setCookie).contains("REFRESH_TOKEN=");
+    assertThat(setCookie).contains("Max-Age=0");
+  }
+
+  @Test
+  @DisplayName("정상 토큰이면 체인이 진행되고 401을 반환하지 않는다")
+  void validToken_passesFilter() throws Exception {
+    String token = "t.jwt";
+    UUID userId = UUID.randomUUID();
+
+    when(jwtTokenProvider.validateToken(token)).thenReturn(true);
+    doReturn(userId).when(jwtTokenProvider).getUserIdFromToken(token);
+    when(jwtTokenProvider.getJti(token)).thenReturn("jti-ok");
+    when(tokenInvalidationService.isBlacklisted("jti-ok")).thenReturn(false);
+    when(jwtTokenProvider.getIssuedAtEpochSeconds(token)).thenReturn(300L);
+    when(tokenInvalidationService.getUserInvalidAfterMillis(userId.toString())).thenReturn(200_000L); // 200s
+
+    MockHttpServletResponse res = new MockHttpServletResponse();
+    filter.doFilterInternal(authRequest(token), res, new MockFilterChain());
+
+    assertThat(res.getStatus()).isNotEqualTo(401);
+  }
+}
+
+

--- a/src/test/java/com/samsamotot/otboo/common/security/jwt/TokenInvalidationServiceTest.java
+++ b/src/test/java/com/samsamotot/otboo/common/security/jwt/TokenInvalidationServiceTest.java
@@ -1,0 +1,43 @@
+package com.samsamotot.otboo.common.security.jwt;
+
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+@SuppressWarnings("unchecked")
+public class TokenInvalidationServiceTest {
+
+  @Test
+  @DisplayName("ttl<=0이면 블랙리스트 등록을 건너뛴다")
+  void blacklist_skip_on_zero_ttl() {
+    RedisTemplate<String, Object> redis = mock(RedisTemplate.class);
+    TokenInvalidationService svc = new TokenInvalidationService(redis);
+    // 동작만 호출, 예외 없이 통과
+    svc.blacklistJti("jti", 0);
+  }
+
+  @Test
+  @DisplayName("invalidAfter 저장 후 조회가 가능하다")
+  void set_and_get_invalidAfter() {
+    RedisTemplate<String, Object> redis = mock(RedisTemplate.class);
+    ValueOperations<String, Object> ops = mock(ValueOperations.class);
+    when(redis.opsForValue()).thenReturn(ops);
+
+    TokenInvalidationService svc = new TokenInvalidationService(redis);
+    Instant now = Instant.now();
+    svc.setUserInvalidAfter("user-1", now);
+
+    // get 호출 시 mock 동작 정의
+    when(ops.get("jwt:user:user-1:invalidAfter")).thenReturn(now.toEpochMilli());
+    Long read = svc.getUserInvalidAfterMillis("user-1");
+    assertThat(read).isEqualTo(now.toEpochMilli());
+  }
+}
+
+

--- a/src/test/java/com/samsamotot/otboo/user/service/UserServiceImplCutoffTest.java
+++ b/src/test/java/com/samsamotot/otboo/user/service/UserServiceImplCutoffTest.java
@@ -1,0 +1,56 @@
+package com.samsamotot.otboo.user.service;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import com.samsamotot.otboo.common.security.jwt.TokenInvalidationService;
+import com.samsamotot.otboo.profile.repository.ProfileRepository;
+import com.samsamotot.otboo.user.dto.UserRoleUpdateRequest;
+import com.samsamotot.otboo.user.entity.Role;
+import com.samsamotot.otboo.user.entity.User;
+import com.samsamotot.otboo.user.mapper.UserMapper;
+import com.samsamotot.otboo.user.repository.UserRepository;
+import com.samsamotot.otboo.user.service.impl.UserServiceImpl;
+
+public class UserServiceImplCutoffTest {
+
+  @Test
+  @DisplayName("권한 변경 시 invalidAfter=now가 호출된다")
+  void updateRole_setsInvalidAfterNow() {
+    UserRepository userRepository = mock(UserRepository.class);
+    PasswordEncoder passwordEncoder = mock(PasswordEncoder.class);
+    UserMapper userMapper = mock(UserMapper.class);
+    ProfileRepository profileRepository = mock(ProfileRepository.class);
+    TokenInvalidationService tokenInvalidationService = mock(TokenInvalidationService.class);
+
+    UserServiceImpl sut = new UserServiceImpl(
+        userRepository, passwordEncoder, userMapper, profileRepository, tokenInvalidationService);
+
+    UUID userId = UUID.randomUUID();
+    User user = User.builder()
+        .email("user@ex.com")
+        .username("u")
+        .password("p")
+        .role(Role.USER)
+        .isLocked(false)
+        .provider(com.samsamotot.otboo.user.entity.Provider.LOCAL)
+        .build();
+
+    when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+    when(userMapper.toDto(user)).thenReturn(null);
+
+    sut.updateUserRole(userId, new UserRoleUpdateRequest(Role.ADMIN));
+
+    verify(tokenInvalidationService).setUserInvalidAfter(org.mockito.ArgumentMatchers.eq(userId.toString()),
+        org.mockito.ArgumentMatchers.any());
+  }
+}
+
+


### PR DESCRIPTION
## #️⃣ Issue Number
<!-- 관련된 이슈 번호를 적어주세요. 예시:Closes #21 -->
Closes #113

## 📝 요약(Summary)
<!-- 무엇을, 왜 변경했는지 간단히 설명해주세요 -->
권한 변경/로그아웃 시 기존 JWT가 인증에 사용되지 않도록 Redis 기반 컷오프(invalidAfter) + jti 블랙리스트를 도입했습니다.
인증 필터에서 컷오프/블랙리스트를 감지하면 401과 함께 REFRESH_TOKEN 삭제 쿠키를 내려 프론트 수정 없이도 재인증 경로를 차단했습니다.
## 🛠️ PR 변경 사항
<-- 어떤 변경 사항이 있나요? -->

- [x] 기능 추가 (Feature)
- [ ] 버그 수정 (Fix)
- [ ] 코드 리팩토링 (Refactor)
- [x] 테스트 코드 추가/수정 (Test)
- [ ] 문서 수정 (Docs)
- [ ] 스타일/UI 수정 (Style/UI)
- [ ] 빌드/설정 변경 (Build/Config)

- JwtAuthenticationFilter: 컷오프/블랙리스트 검증 추가, 401 응답 시 X-Auth-Error 헤더 및 REFRESH_TOKEN 삭제 쿠키 세팅
- JwtTokenProvider: jti/iat/exp 파싱 헬퍼 추가(getJti, getIssuedAtEpochSeconds, getExpirationTime)
- TokenInvalidationService: jti 블랙리스트 등록/조회, 사용자 invalidAfter 저장/조회 유틸 추가
- UserServiceImpl: 권한 변경 시 invalidAfter=now 저장(기존 토큰 일괄 무효화)
- AuthServiceImpl: 로그아웃 시 리프레시 토큰 jti 블랙리스트 등록(TTL=남은 유효시간)

## 📸스크린샷 (선택)
<!-- UI 변경이 있다면 Before / After 스크린샷을 첨부해주세요 -->

## 💬 리뷰 포인트 / 논의사항
<!-- 리뷰어가 집중해서 봐야 하는 부분이나 논의가 필요한 내용을 적어주세요 -->
<!-- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist
<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] 커밋 메시지를 컨벤션에 맞게 작성했습니다.
- [x] 코드 스타일/린트 검사를 통과했습니다.
- [x] 변경 사항에 대한 테스트를 수행했습니다.
- [ ] 문서(README 등)를 최신 상태로 업데이트했습니다. (해당 시)
- [ ] 리뷰어 피드백을 반영했습니다. (PR 업데이트 시)
